### PR TITLE
Convert use of gethostbyname() to use getaddrinfo()

### DIFF
--- a/lib/plugins/stonith/apcmastersnmp.c
+++ b/lib/plugins/stonith/apcmastersnmp.c
@@ -716,6 +716,7 @@ apcmastersnmp_set_config(StonithPlugin * s, StonithNVpair * list)
 	struct pluginDevice* sd = (struct pluginDevice *)s;
 	int	rc;
 	int *	i;
+	struct addrinfo *res;
 	StonithNamesToGet	namestocopy [] =
 	{	{ST_IPADDR,	NULL}
 	,	{ST_PORT,	NULL}
@@ -737,9 +738,12 @@ apcmastersnmp_set_config(StonithPlugin * s, StonithNVpair * list)
 	PluginImports->mfree(namestocopy[1].s_value);
 	sd->community = namestocopy[2].s_value;
 
-        /* try to resolve the hostname/ip-address */
-	if (gethostbyname(sd->hostname) != NULL) {
-        	/* init snmp library */
+	/* try to resolve the hostname/ip-address */
+
+	rc = getaddrinfo(sd->hostname, NULL, NULL, &res);
+	if (rc == 0) {
+		freeaddrinfo(res);
+		/* init snmp library */
 		init_snmp("apcmastersnmp");
 
 		/* now try to get a snmp session */
@@ -747,7 +751,7 @@ apcmastersnmp_set_config(StonithPlugin * s, StonithNVpair * list)
 
 			/* ok, get the number of outlets from the masterswitch */
 			if ((i = APC_read(sd->sptr, OID_NUM_OUTLETS, ASN_INTEGER))
-                    		== NULL) {
+				== NULL) {
 				LOG(PIL_CRIT
 				, "%s: cannot read number of outlets."
 				,       __FUNCTION__);
@@ -767,8 +771,8 @@ apcmastersnmp_set_config(StonithPlugin * s, StonithNVpair * list)
 			,       __FUNCTION__);
 		}
 	}else{
-		LOG(PIL_CRIT, "%s: cannot resolve hostname '%s', h_errno %d."
-		,       __FUNCTION__, sd->hostname, h_errno);
+		LOG(PIL_CRIT, "%s: cannot resolve hostname '%s', %s."
+		,       __FUNCTION__, sd->hostname, gai_strerror(rc));
 	}
 
 	/* not a valid config */

--- a/lib/plugins/stonith/ipmilan_command.c
+++ b/lib/plugins/stonith/ipmilan_command.c
@@ -23,7 +23,7 @@
 #include <stdlib.h> /* malloc() */
 #include <unistd.h> /* getopt() */
 #include <string.h> /* strerror() */
-#include <netdb.h> /* gethostbyname() */
+#include <netdb.h> /* getaddrinfo() */
 #include <sys/types.h>
 #include <sys/socket.h>
 
@@ -260,9 +260,9 @@ con_changed_handler(ipmi_con_t *ipmi, int err, unsigned int port_num,
 static int
 setup_ipmi_conn(struct ipmilanHostInfo * host, int *request)
 {
-	int rv;
+	int rv, rc;
 
-	struct hostent *ent;
+	struct addrinfo *res;
 	struct in_addr lan_addr[2];
 	int lan_port[2];
 	int num_addr = 1;
@@ -293,13 +293,13 @@ setup_ipmi_conn(struct ipmilanHostInfo * host, int *request)
 		return rv;
 	}
 
-	ent = gethostbyname(host->ipaddr);
-	if (!ent) {
-		PILCallLog(PluginImports->log,PIL_CRIT, "gethostbyname failed: %s\n", strerror(h_errno));
+	rc = getaddrinfo(host->ipaddr, NULL, NULL, &res);
+	if (rc != 0) {
+		PILCallLog(PluginImports->log,PIL_CRIT, "getaddrinfo failed: %s\n", gai_strerror(rc));
 		return 1;
 	}
 
-	memcpy(&lan_addr[0], ent->h_addr_list[0], ent->h_length);
+	memcpy(&lan_addr[0], res->ai_addr, res->ai_addrlen);
 	lan_port[0] = host->portnumber;
 	lan_port[1] = 0;
 

--- a/lib/plugins/stonith/wti_mpc.c
+++ b/lib/plugins/stonith/wti_mpc.c
@@ -650,6 +650,7 @@ static int
 wti_mpc_set_config(StonithPlugin * s, StonithNVpair * list)
 {
 	struct pluginDevice* sd = (struct pluginDevice *)s;
+	struct addrinfo *res;
 	int	rc;
 	char *	i;
     int mo;
@@ -679,7 +680,8 @@ wti_mpc_set_config(StonithPlugin * s, StonithNVpair * list)
 	PluginImports->mfree(namestocopy[3].s_value);
 
         /* try to resolve the hostname/ip-address */
-	if (gethostbyname(sd->hostname) != NULL) {
+	if ((rc = getaddrinfo(sd->hostname, NULL, NULL, &res)) == 0) {
+		freeaddrinfo(res);
         	/* init snmp library */
 		init_snmp("wti_mpc");
 
@@ -732,8 +734,8 @@ wti_mpc_set_config(StonithPlugin * s, StonithNVpair * list)
 			,       __FUNCTION__);
 		}
 	}else{
-		LOG(PIL_CRIT, "%s: cannot resolve hostname '%s', h_errno %d."
-		,       __FUNCTION__, sd->hostname, h_errno);
+		LOG(PIL_CRIT, "%s: cannot resolve hostname '%s', %s."
+		,       __FUNCTION__, sd->hostname, gai_strerror(rc));
 	}
 
 	/* not a valid config */


### PR DESCRIPTION
Since `gethostbyname` is deprecated and considered unsafe, I converted the uses I found to getaddrinfo() instead.

I haven't tested these changes beyond compiling, so please don't merge blindly. :)
