### PR TITLE
High: external/ec2: Avoid unicode errors and improve performance

### DIFF
--- a/lib/plugins/stonith/external/ec2
+++ b/lib/plugins/stonith/external/ec2
@@ -20,6 +20,7 @@ then the agent should be able to automatically discover the instances it can con
 If the tag containing the uname is not [Name], then it will need to be specified using the [tag] option.
 "
 
+
 #
 # Copyright (c) 2011-2013 Andrew Beekhof
 # Copyright (c) 2014 NIPPON TELEGRAPH AND TELEPHONE CORPORATION
@@ -69,15 +70,15 @@ function usage()
 {
 cat <<EOF
 `basename $0` - A fencing agent for Amazon EC2 instances
- 
+
 $description
- 
+
 Usage: `basename $0` -o|--action [-n|--port] [options]
 Options:
  -h, --help 		This text
  -V, --version		Version information
  -q, --quiet 		Reduced output mode
- 
+
 Commands:
  -o, --action		Action to perform: on|off|reboot|status|monitor
  -n, --port 		The name of a machine/instance to control/check
@@ -90,7 +91,7 @@ Dangerous options:
  -U, --unknown-are-stopped 	Assume any unknown instance is safely stopped
 
 EOF
-    exit 0;
+	exit 0;
 }
 
 function getinfo_xml()
@@ -229,11 +230,11 @@ function monitor()
 }
 
 TEMP=`getopt -o qVho:e:p:n:t:U --long version,help,action:,port:,option:,profile:,tag:,quiet,unknown-are-stopped \
-     -n 'fence_ec2' -- "$@"`
+	-n 'fence_ec2' -- "$@"`
 
-if [ $? != 0 ];then 
-    usage
-    exit 1
+if [ $? != 0 ]; then
+	usage
+	exit 1
 fi
 
 # Note the quotes around `$TEMP': they are essential!
@@ -242,7 +243,7 @@ eval set -- "$TEMP"
 if [ -z $1 ]; then
 	# If there are no command line args, look for options from stdin
 	while read line; do
-		case $line in 
+		case $line in
 			option=*|action=*) action=`echo $line | sed s/.*=//`;;
 			port=*)        port=`echo $line | sed s/.*=//`;;
 			profile=*)     ec2_profile=`echo $line | sed s/.*=//`;;
@@ -264,7 +265,7 @@ while true ; do
 		-U|--unknown-are-stopped) unknown_are_stopped=1; shift;;
 		-q|--quiet) quiet=1; shift;;
 		-V|--version) echo "1.0.0"; exit 0;;
-		--help|-h) 
+		--help|-h)
 			usage;
 			exit 0;;
 		--) shift ; break ;;
@@ -283,7 +284,7 @@ fi
 
 action=`echo $action | tr 'A-Z' 'a-z'`
 
-case $action in 
+case $action in
 	metadata)
 		metadata
 	;;
@@ -343,7 +344,7 @@ if [ ! -z "$port" ]; then
 	instance=`instance_for_port $port $options`
 fi
 
-case $action in 
+case $action in
 	reboot|reset)
 		status=`instance_status $instance`
 		if [ "$status" != "stopped" ]; then

--- a/lib/plugins/stonith/external/ec2
+++ b/lib/plugins/stonith/external/ec2
@@ -22,6 +22,8 @@ If the tag containing the uname is not [Name], then it will need to be specified
 
 
 #
+# Copyright (c) 2018 Stefan Schneider <stsch@amazon.de>
+# Copyright (c) 2018 Kristoffer Gronlund <kgronlund@suse.com>
 # Copyright (c) 2011-2013 Andrew Beekhof
 # Copyright (c) 2014 NIPPON TELEGRAPH AND TELEPHONE CORPORATION
 #                    All Rights Reserved.
@@ -174,11 +176,7 @@ function instance_for_port()
 	local instance=""
 
 	# Look for port name -n in the INSTANCE data
-	instance=`aws ec2 describe-instances $options | grep "^INSTANCES[[:space:]].*[[:space:]]$port[[:space:]]" | awk '{print $8}'`
-	if [ -z $instance ]; then
-		# Look for port name -n in the Name TAG
-		instance=`aws ec2 describe-tags $options | grep "^TAGS[[:space:]]$ec2_tag[[:space:]].*[[:space:]]instance[[:space:]]$port$" | awk '{print $3}'`
-	fi
+	instance=`aws ec2 describe-instances $options --filters "Name=tag-value,Values=${port}" "Name=tag-key,Values=${ec2_tag}" --query 'Reservations[*].Instances[*].InstanceId'  `
 
 	if [ -z $instance ]; then
 		instance_not_found=1
@@ -213,9 +211,7 @@ function instance_status()
 	if [ "$unknown_are_stopped" = 1 -a $instance_not_found ]; then
 		ha_log.sh info "$instance stopped (unknown)"
 	else
-		status=`aws ec2 describe-instances $options --instance-ids $instance | awk '{ 
-			if (/^STATE\t/) { printf "%s", $3 }
-			}'`
+		status=`aws ec2 describe-instances $options --instance-ids $instance --query 'Reservations[*].Instances[*].State.Name' `
 		rc=$?
 	fi
 	ha_log.sh info "status check for $instance is $status"
@@ -226,7 +222,7 @@ function instance_status()
 function monitor()
 {
 		# Is the device ok?
-		aws ec2 describe-instances $options | grep INSTANCES &> /dev/null
+		aws ec2 describe-instances $options --filters "Name=tag-key,Values=${ec2_tag}" | grep INSTANCES &> /dev/null
 }
 
 TEMP=`getopt -o qVho:e:p:n:t:U --long version,help,action:,port:,option:,profile:,tag:,quiet,unknown-are-stopped \
@@ -394,10 +390,7 @@ case $action in
 	;;
 	gethosts|hostlist|list)
 		# List of names we know about
-		a=`aws ec2 describe-instances $options | awk -v tag_pat="^TAGS\t$ec2_tag\t" -F '\t' '{ 
-			if (/^INSTANCES/) { printf "%s\n", $8 }
-			else if ( $1"\t"$2"\t" ~ tag_pat ) { printf "%s\n", $3 }
-			}' | sort -u`
+		a=`aws ec2 describe-instances $options --filters "Name=tag-key,Values=${ec2_tag}" --query 'Reservations[*].Instances[*].Tags[?Key==\`'${ec2_tag}'\`].Value' | sort -u`
 		echo $a
 	;;
 	stat|status)


### PR DESCRIPTION
Originally by stsch@amazon.de:

All AWS CLI describe commands have been changed to report the result directly.

This has the following advantages:

* No more unicode errors when other tags use UNICODE characters.
* No more interpreatation errors with aws and grep if the text format changes.
* Faster execution due to significantly reduced result sets.
