### PR TITLE
ibmhmc: Create /var/run/heartbeat/rsctmp if it doesn't exist

### DIFF
--- a/lib/plugins/stonith/ibmhmc.c
+++ b/lib/plugins/stonith/ibmhmc.c
@@ -1135,7 +1135,7 @@ do_shell_cmd(const char* cmd, int* status, const char* password)
 		snprintf(cmd_password, MAX_CMD_LEN
 		,"umask 077;"
 		 "if [ ! -d  " HA_VARRUNDIR "/heartbeat/rsctmp/ibmhmc ];"
-		 "then mkdir " HA_VARRUNDIR "/heartbeat/rsctmp/ibmhmc 2>/dev/null;"
+		 "then mkdir -p " HA_VARRUNDIR "/heartbeat/rsctmp/ibmhmc 2>/dev/null;"
 		 "fi;"
 		 "export ibmhmc_tmp=`mktemp -p " HA_VARRUNDIR "/heartbeat/rsctmp/ibmhmc/`;" 
 		 "echo \"echo '%s'\">$ibmhmc_tmp;" 


### PR DESCRIPTION
Since /var/run is considered a volatile / runtime location, agents
shouldn't count on certain directories existing there. Besides, it
was unclear who was actually supposed to have created the
/var/run/heartbeat/rsctmp directory: Seems it used to be the
resource-agents package once, so even then it didn't make sense for
stonith agents to rely on it existing.

ibmhmc seems to be the only case where this assumption was made.

SUSE Bugzilla reference: bsc#1131545
