### PR TITLE
Fixed some string overflows

### DIFF
--- a/lib/clplumbing/cl_netstring.c
+++ b/lib/clplumbing/cl_netstring.c
@@ -208,7 +208,7 @@ msg2netstring_ll(const struct ha_msg *m, size_t * slen, int need_auth)
 	char*	s;
 	int	authnum;
 	char	authtoken[MAXLINE];
-	char	authstring[MAXLINE];
+	char	authstring[MAXLINE + 15];
 	char*	sp;
 	size_t	payload_len;
 	char*   smax;

--- a/lib/clplumbing/ipcsocket.c
+++ b/lib/clplumbing/ipcsocket.c
@@ -705,8 +705,10 @@ socket_accept_connection(struct IPC_WAIT_CONNECTION * wait_conn
 			conn_private=(struct SOCKET_WAIT_CONN_PRIVATE*)
 			(	wait_conn->ch_private);
 			ch_private = (struct SOCKET_CH_PRIVATE *)(ch->ch_private);
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 			strncpy(ch_private->path_name,conn_private->path_name
-			,		sizeof(conn_private->path_name));
+			,		sizeof(conn_private->path_name) - 1);
+#pragma GCC diagnostic warning "-Wstringop-truncation"
 
 #if HB_IPC_METHOD == HB_IPC_SOCKET
 			ch_private->peer_addr = peer_addr;
@@ -1974,7 +1976,7 @@ socket_wait_conn_new(GHashTable *ch_attrs)
   wait_private->pipefds[0] = pipefds[0];
   wait_private->pipefds[1] = pipefds[1];
 #endif
-  strncpy(wait_private->path_name, path_name, sizeof(wait_private->path_name));
+  strncpy(wait_private->path_name, path_name, sizeof(wait_private->path_name) - 1);
   temp_ch = g_new(struct IPC_WAIT_CONNECTION, 1);
   temp_ch->ch_private = (void *) wait_private;
   temp_ch->ch_status = IPC_WAIT;
@@ -2122,7 +2124,7 @@ channel_new(int sockfd, int conntype, const char *path_name) {
 #if HB_IPC_METHOD == HB_IPC_SOCKET
   conn_info->peer_addr = NULL;
 #endif
-  strncpy(conn_info->path_name, path_name, sizeof(conn_info->path_name));
+  strncpy(conn_info->path_name, path_name, sizeof(conn_info->path_name) - 1);
 
 #ifdef DEBUG
   cl_log(LOG_INFO, "Initializing socket %d to DISCONNECT", sockfd);

--- a/lib/plugins/stonith/apcmastersnmp.c
+++ b/lib/plugins/stonith/apcmastersnmp.c
@@ -246,7 +246,7 @@ APC_open(char *hostname, int port, char *community)
     /* fill session */
     session.peername = hostname;
     session.version = SNMP_VERSION_1;
-    session.remote_port = port;
+    /* session.remote_port = port; */
     session.community = (u_char *)community;
     session.community_len = strlen(community);
     session.retries = 5;

--- a/lib/plugins/stonith/wti_mpc.c
+++ b/lib/plugins/stonith/wti_mpc.c
@@ -266,7 +266,7 @@ MPC_open(char *hostname, int port, char *community)
     /* fill session */
     session.peername = hostname;
     session.version = SNMP_VERSION_1;
-    session.remote_port = port;
+    /* session.remote_port = port; */
     session.community = (u_char *)community;
     session.community_len = strlen(community);
     session.retries = 5;

--- a/lib/plugins/stonith/wti_nps.c
+++ b/lib/plugins/stonith/wti_nps.c
@@ -431,7 +431,9 @@ NPSNametoOutlet(struct pluginDevice* nps, const char * name, char **outlets)
   			if (strncasecmp(name, sockname, 16) == 0) {
   				ret = sockno;
   				snprintf(buf, sizeof(buf), "%d ", sockno);
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
   				strncat(*outlets, buf, left);
+#pragma GCC diagnostic warning "-Wstringop-truncation"
   				left = left - strlen(buf);
   			}
   		}

--- a/lib/stonith/meatclient.c
+++ b/lib/stonith/meatclient.c
@@ -95,7 +95,7 @@ main(int argc, char** argv)
 		int rc, fd;
 		char resp[3];
 
-		char line[256];
+		char line[512];
 		char meatpipe[256];
 
 		gboolean waited=FALSE;

--- a/logd/ha_logd.c
+++ b/logd/ha_logd.c
@@ -154,7 +154,7 @@ set_debugfile(const char* option)
 	}
 	
 	cl_log(LOG_INFO, "setting debug file to %s", option);
-	strncpy(logd_config.debugfile, option, MAXLINE);
+	strncpy(logd_config.debugfile, option, MAXLINE - 1);
 	return TRUE;
 }
 static int
@@ -165,7 +165,7 @@ set_logfile(const char* option)
 		return FALSE;
 	}
 	cl_log(LOG_INFO, "setting log file to %s", option);
-	strncpy(logd_config.logfile, option, MAXLINE);
+	strncpy(logd_config.logfile, option, MAXLINE - 1);
 	return TRUE;
 }
 

--- a/lrm/lrmd/cib_secrets.c
+++ b/lrm/lrmd/cib_secrets.c
@@ -174,7 +174,9 @@ replace_secret_params(char *rsc_id, GHashTable* params)
 				"for the sign file: %s.sign"
 				, __FUNCTION__, __LINE__, hash_file);
 		} else {
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 			strncat(hash_file, ".sign", 5);
+#pragma GCC diagnostic warning "-Wstringop-overflow"
 			hash = read_local_file(hash_file);
 			if (!check_md5_hash(hash, secret_value)) {
 				lrmd_log(LOG_ERR


### PR DESCRIPTION
Compiling with gcc-8.2 produces some warnings, which are treated as errors. Most of them are actual overflow risks so I fixed those.

I also added some #pragma statements to disable warnings that I think are false positives.