### PR TITLE
Fix EC2 stonith plugin

### DIFF
--- a/lib/plugins/stonith/external/ec2
+++ b/lib/plugins/stonith/external/ec2
@@ -53,14 +53,19 @@ quiet=0
 instance_not_found=0
 unknown_are_stopped=0
 
-action_default="reset"         # Default fence action
-ec2_tag_default="Name"	       # EC2 Tag containing the instance's uname
+action_default="reset"	    	# Default fence action
+ec2_tag_default="Name"	    	# EC2 Tag containing the instance's uname
+ec2_profile_default="default"	# EC2 Profile containing the AWS's profile
 
 sleep_time="1"
 
+# Set the correct value for the tag
 [ -n "$tag" ] && ec2_tag="$tag"
-
 : ${ec2_tag=${ec2_tag_default}}
+
+# Set the correct value for the profile
+[ -n "$profile" ] && ec2_profile="$profile"
+: ${ec2_profile=${ec2_profile_default}}
 
 # Always invoke aws command with UTF-8 locale
 # to avoid issues when the tag contains non-ASCII
@@ -299,12 +304,7 @@ done
 [ -n "$1" ] && action=$1
 [ -n "$2" ] && node_to_fence=$2
 
-if [ -z "$ec2_profile"]; then
-	options="--output text --profile default"
-else
-	options="--output text --profile $ec2_profile "
-fi
-
+options="--output text --profile $ec2_profile"
 action=`echo $action | tr 'A-Z' 'a-z'`
 
 case $action in


### PR DESCRIPTION
The `profile` parameter is not handled correctly in EC2 stonith plugin.
This commit fix it using the same way as the `tag` variable.

I was able to track this by adding a `set -x` in the plugin script.

RA configuration:

    primitive res_aws_stonith_PRD_HDB00 stonith:external/ec2 \
        params tag=Cluster profile=Cluster \
        op start interval=0 timeout=180 \
        op stop interval=0 timeout=180 \
        op monitor interval=120 timeout=60

Result:

    Apr 17 13:54:47 hana02 pacemaker-fenced[7538]:  warning: fence_legacy[26681] stderr: [ + options='--output text --profile default' ]

Instead of:

    Apr 17 13:54:47 hana02 pacemaker-fenced[7538]:  warning: fence_legacy[26681] stderr: [ + options='--output text --profile Cluster' ]