### PR TITLE
Fix ftbfs werror deprecated symbols format stringop

### DIFF
--- a/lib/clplumbing/cl_netstring.c
+++ b/lib/clplumbing/cl_netstring.c
@@ -208,7 +208,7 @@ msg2netstring_ll(const struct ha_msg *m, size_t * slen, int need_auth)
 	char*	s;
 	int	authnum;
 	char	authtoken[MAXLINE];
-	char	authstring[MAXLINE];
+	char	authstring[MAXLINE+12];
 	char*	sp;
 	size_t	payload_len;
 	char*   smax;
@@ -249,7 +249,7 @@ msg2netstring_ll(const struct ha_msg *m, size_t * slen, int need_auth)
 			return(NULL);
 		}
 		
-		sprintf(authstring, "%d %s", authnum, authtoken);
+		snprintf(authstring, sizeof(authstring), "%d %s", authnum, authtoken);
 		auth_strlen = strlen(authstring);
 		if (sp  + 2 + auth_strlen + bytes_for_int(auth_strlen)  >= smax){
 			cl_log(LOG_ERR, "%s: out of boundary for auth", __FUNCTION__);

--- a/lib/clplumbing/ipcsocket.c
+++ b/lib/clplumbing/ipcsocket.c
@@ -1967,14 +1967,14 @@ socket_wait_conn_new(GHashTable *ch_attrs)
     return NULL;
   }
 
-  wait_private =  g_new(struct SOCKET_WAIT_CONN_PRIVATE, 1);
+  wait_private =  g_new0(struct SOCKET_WAIT_CONN_PRIVATE, 1);
 #if HB_IPC_METHOD == HB_IPC_SOCKET
   wait_private->s = s;
 #elif HB_IPC_METHOD == HB_IPC_STREAM
   wait_private->pipefds[0] = pipefds[0];
   wait_private->pipefds[1] = pipefds[1];
 #endif
-  strncpy(wait_private->path_name, path_name, sizeof(wait_private->path_name));
+  strlcpy(wait_private->path_name, path_name, sizeof(wait_private->path_name));
   temp_ch = g_new(struct IPC_WAIT_CONNECTION, 1);
   temp_ch->ch_private = (void *) wait_private;
   temp_ch->ch_status = IPC_WAIT;
@@ -2090,14 +2090,13 @@ channel_new(int sockfd, int conntype, const char *path_name) {
 	return NULL;
   }
 
-  temp_ch = g_new(struct IPC_CHANNEL, 1);
+  temp_ch = g_new0(struct IPC_CHANNEL, 1);
   if (temp_ch == NULL) {
 	  cl_log(LOG_ERR, "channel_new: allocating memory for channel failed");
 	  return NULL;
   }
-  memset(temp_ch, 0, sizeof(struct IPC_CHANNEL));
 
-  conn_info = g_new(struct SOCKET_CH_PRIVATE, 1);
+  conn_info = g_new0(struct SOCKET_CH_PRIVATE, 1);
 
   flags = fcntl(sockfd, F_GETFL);
   if (flags == -1) {
@@ -2122,7 +2121,7 @@ channel_new(int sockfd, int conntype, const char *path_name) {
 #if HB_IPC_METHOD == HB_IPC_SOCKET
   conn_info->peer_addr = NULL;
 #endif
-  strncpy(conn_info->path_name, path_name, sizeof(conn_info->path_name));
+  strlcpy(conn_info->path_name, path_name, sizeof(conn_info->path_name));
 
 #ifdef DEBUG
   cl_log(LOG_INFO, "Initializing socket %d to DISCONNECT", sockfd);

--- a/lib/clplumbing/ipctest.c
+++ b/lib/clplumbing/ipctest.c
@@ -1140,7 +1140,7 @@ s_send_msg(gpointer data)
 			return FALSE;
 		}
 		if (i->errcount >= MAXERRORS) {
-			g_main_quit(loop);
+			g_main_loop_quit(loop);
 			return FALSE;
 		}
 	}
@@ -1198,7 +1198,7 @@ s_rcv_msg(IPC_Channel* chan, gpointer data)
 			++i->errcount;
 			cl_log(LOG_INFO, "Early exit from s_rcv_msg");
 		}
-		g_main_quit(loop);
+		g_main_loop_quit(loop);
 		return FALSE;
 	}
 
@@ -1316,7 +1316,7 @@ s_echo_msg(IPC_Channel* chan, gpointer data)
 	if (i->rcount >= i->max || chan->ch_status == IPC_DISCONNECT
 	    ||	i->errcount > MAXERRORS) {
 		chan->ops->waitout(chan);
-		g_main_quit(loop);
+		g_main_loop_quit(loop);
 		return FALSE;
 	}
 	return TRUE;
@@ -1339,7 +1339,7 @@ mainloop_server(IPC_Channel* chan, int repcount)
 
 	
 
-	loop = g_main_new(FALSE);
+	loop = g_main_loop_new(NULL, FALSE);
 	init_iterinfo(&info, chan, repcount);
 
 	chan->ops->set_high_flow_callback(chan, mainloop_high_flow_callback, &info);
@@ -1351,8 +1351,8 @@ mainloop_server(IPC_Channel* chan, int repcount)
 	G_main_add_IPC_Channel(G_PRIORITY_DEFAULT, chan
 	,	FALSE, s_rcv_msg, &info, NULL);
 	cl_log(LOG_INFO, "Mainloop echo server: %d reps pid %d.", repcount, (int)getpid());
-	g_main_run(loop);
-	g_main_destroy(loop);
+	g_main_loop_run(loop);
+	g_main_loop_unref(loop);
 	g_source_remove(sendmsgsrc);
 	loop = NULL;
 	cl_log(LOG_INFO, "Mainloop echo server: %d errors", info.errcount);
@@ -1362,13 +1362,13 @@ static int
 mainloop_client(IPC_Channel* chan, int repcount)
 {
 	struct iterinfo info;
-	loop = g_main_new(FALSE);
+	loop = g_main_loop_new(NULL, FALSE);
 	init_iterinfo(&info, chan, repcount);
 	G_main_add_IPC_Channel(G_PRIORITY_DEFAULT, chan
 	,	FALSE, s_echo_msg, &info, NULL);
 	cl_log(LOG_INFO, "Mainloop echo client: %d reps pid %d.", repcount, (int)getpid());	
-	g_main_run(loop);
-	g_main_destroy(loop);
+	g_main_loop_run(loop);
+	g_main_loop_unref(loop);
 	loop = NULL;
 	cl_log(LOG_INFO, "Mainloop echo client: %d errors, %d read %d written"
 	,	info.errcount, info.rcount, info.wcount);

--- a/lib/clplumbing/ipctransientclient.c
+++ b/lib/clplumbing/ipctransientclient.c
@@ -45,7 +45,7 @@ main(int argc, char ** argv)
     
 	/* give the server a chance to start */
 	cl_log(LOG_INFO, "#--#--#--#--# Beginning test run %d against server %d...", lpc, iteration);
-	client_main = g_main_new(FALSE);
+	client_main = g_main_loop_new(NULL, FALSE);
     
 	/* connect, send messages */
 	server_channel = init_client_ipctest_comms("echo", transient_client_callback, client_main);
@@ -76,7 +76,7 @@ main(int argc, char ** argv)
 	 */
     
 	cl_log(LOG_DEBUG, "Waiting for replies from the echo server");
-	g_main_run(client_main);
+	g_main_loop_run(client_main);
 	cl_log(LOG_INFO, "[Iteration %d] Client %d completed successfully", iteration, lpc);
 
 	return 0;
@@ -182,7 +182,7 @@ transient_client_callback(IPC_Channel* server, void* private_data)
 	if(received_responses > 2) {
 		cl_log(LOG_INFO, "[Client] Processed %d IPC messages, all done.", received_responses);
 		received_responses = 0;
-		g_main_quit(mainloop);
+		g_main_loop_quit(mainloop);
 		cl_log(LOG_INFO, "[Client] Exiting.");
 		return FALSE;
 	}

--- a/lib/clplumbing/ipctransientserver.c
+++ b/lib/clplumbing/ipctransientserver.c
@@ -40,10 +40,10 @@ main(int argc, char ** argv)
     /* wait for the reply by creating a mainloop and running it until
      * the callbacks are invoked...
      */
-    mainloop = g_main_new(FALSE);
+    mainloop = g_main_loop_new(NULL, FALSE);
 
     cl_log(LOG_INFO, "#--#--#--# Echo Server %d is active...", iteration);
-    g_main_run(mainloop);
+    g_main_loop_run(mainloop);
     cl_log(LOG_INFO, "#--#--#--# Echo Server %d is stopped...", iteration);
 
 	return 0;

--- a/lib/plugins/lrm/raexechb.c
+++ b/lib/plugins/lrm/raexechb.c
@@ -389,7 +389,7 @@ get_resource_meta(const char* rsc_type,  const char* provider)
 	GString * meta_data;
 
 	meta_data = g_string_new("");
-	g_string_sprintf( meta_data, meta_data_template, rsc_type
+	g_string_printf( meta_data, meta_data_template, rsc_type
 			, rsc_type, rsc_type);
 	return meta_data->str;
 }

--- a/lib/plugins/lrm/raexeclsb.c
+++ b/lib/plugins/lrm/raexeclsb.c
@@ -560,7 +560,7 @@ get_resource_meta(const char* rsc_type,  const char* provider)
 	}
 	fclose(fp);
 	
-	g_string_sprintf( meta_data, meta_data_template, rsc_type
+	g_string_printf( meta_data, meta_data_template, rsc_type
 			, (xml_l_dscrpt==NULL)? rsc_type : xml_l_dscrpt
 			, (s_dscrpt==NULL)? rsc_type : s_dscrpt
 			, (provides==NULL)? "" : provides

--- a/lib/stonith/meatclient.c
+++ b/lib/stonith/meatclient.c
@@ -95,7 +95,7 @@ main(int argc, char** argv)
 		int rc, fd;
 		char resp[3];
 
-		char line[256];
+		char line[320];
 		char meatpipe[256];
 
 		gboolean waited=FALSE;

--- a/logd/ha_logd.c
+++ b/logd/ha_logd.c
@@ -145,6 +145,8 @@ logd_log( const char * fmt, ...)
 	return;
 }
 
+#define str_assign(dst, src) strlcpy(dst, src, sizeof(dst))
+
 static int
 set_debugfile(const char* option)
 {
@@ -154,7 +156,7 @@ set_debugfile(const char* option)
 	}
 	
 	cl_log(LOG_INFO, "setting debug file to %s", option);
-	strncpy(logd_config.debugfile, option, MAXLINE);
+	str_assign(logd_config.debugfile, option);
 	return TRUE;
 }
 static int
@@ -165,7 +167,7 @@ set_logfile(const char* option)
 		return FALSE;
 	}
 	cl_log(LOG_INFO, "setting log file to %s", option);
-	strncpy(logd_config.logfile, option, MAXLINE);
+	str_assign(logd_config.logfile, option);
 	return TRUE;
 }
 
@@ -193,7 +195,7 @@ set_entity(const char * option)
 		logd_config.entity[0] = EOS;
 		return FALSE;
 	}
-	strncpy(logd_config.entity, option, MAXENTITY);
+	str_assign(logd_config.entity, option);
 	logd_config.entity[MAXENTITY-1] = '\0';
 	if (strlen(option) >= MAXENTITY)
 		cl_log(LOG_WARNING, "setting entity to %s (truncated from %s)",
@@ -211,7 +213,7 @@ set_syslogprefix(const char * option)
 		logd_config.syslogprefix[0] = EOS;
 		return FALSE;
 	}
-	strncpy(logd_config.syslogprefix, option, MAXENTITY);
+	str_assign(logd_config.syslogprefix, option);
 	logd_config.syslogprefix[MAXENTITY-1] = '\0';
 	if (strlen(option) >= MAXENTITY)
 		cl_log(LOG_WARNING,
@@ -429,7 +431,7 @@ on_receive_cmd (IPC_Channel* ch, gpointer user_data)
 		if (client->app_name[0] == '\0'){
 			LogDaemonMsgHdr*	logmsghdr;
 			logmsghdr = (LogDaemonMsgHdr*) ipcmsg->msg_body;
-			strncpy(client->app_name, logmsghdr->entity, MAXENTITY);
+			str_assign(client->app_name, logmsghdr->entity);
 		}
 
 		if (!IPC_ISWCONN(logchan)){

--- a/logd/ha_logd.c
+++ b/logd/ha_logd.c
@@ -719,7 +719,7 @@ logd_term_action(int sig, gpointer userdata)
 		
 	}
 	
-        g_main_quit(mainloop);
+        g_main_loop_quit(mainloop);
 	
         return TRUE;
 }
@@ -751,7 +751,7 @@ read_msg_process(IPC_Channel* chan)
 
 	
 
-	mainloop = g_main_new(FALSE);       
+	mainloop = g_main_loop_new(NULL, FALSE);
 	
 	G_main_add_SignalHandler(G_PRIORITY_HIGH, SIGTERM, 
 				 logd_term_action,mainloop, NULL);
@@ -780,7 +780,7 @@ read_msg_process(IPC_Channel* chan)
 	
 	G_main_add_SignalHandler(G_PRIORITY_DEFAULT, SIGHUP, 
 				 logd_hup_action, mainloop, NULL);
-	g_main_run(mainloop);
+	g_main_loop_run(mainloop);
 	
 	return;
 }
@@ -855,7 +855,7 @@ direct_log(IPC_Channel* ch, gpointer user_data)
 
 	if(needs_shutdown) {
 		cl_log(LOG_INFO, "Exiting write process");
-		g_main_quit(loop);
+		g_main_loop_quit(loop);
 		return FALSE;
 	}
 	return TRUE;
@@ -885,7 +885,7 @@ write_msg_process(IPC_Channel* readchan)
 	IPC_Channel*	ch = readchan;
 	
 	
-	mainloop = g_main_new(FALSE);   
+	mainloop = g_main_loop_new(NULL, FALSE);
 	
 	G_main_add_IPC_Channel(G_PRIORITY_DEFAULT,
 			       ch, FALSE,
@@ -897,7 +897,7 @@ write_msg_process(IPC_Channel* readchan)
 	G_main_add_SignalHandler(G_PRIORITY_DEFAULT, SIGHUP, 
 				 logd_hup_action, mainloop, NULL);
 	
-	g_main_run(mainloop);
+	g_main_loop_run(mainloop);
 	
 }
 

--- a/logd/logtest.c
+++ b/logd/logtest.c
@@ -55,13 +55,13 @@ send_log_msg(gpointer data)
 	
 	if (chan == NULL){
 		cl_log(LOG_ERR, "logging channel is NULL");
-		g_main_quit(loop);
+		g_main_loop_quit(loop);
 		return FALSE;
 
 	}
 	if (count >= maxcount){
 		cl_log(LOG_INFO, "total message dropped: %d", dropmsg);
-		g_main_quit(loop);
+		g_main_loop_quit(loop);
 		return FALSE;
 	}
 	
@@ -121,7 +121,7 @@ main(int argc, char** argv)
 	
 
 	loop = g_main_loop_new(NULL, FALSE);
-	g_main_run(loop);
+	g_main_loop_run(loop);
 	return(1);
 	
 }

--- a/lrm/admin/lrmadmin.c
+++ b/lrm/admin/lrmadmin.c
@@ -603,9 +603,9 @@ int main(int argc, char **argv)
 			Gmain_timeout_add(TIMEOUT, lrm_op_timeout, &ret_value);
 		}
 
-		mainloop = g_main_new(FALSE);
+		mainloop = g_main_loop_new(NULL, FALSE);
 		printf( "Waiting for lrmd to callback...\n");
-        	g_main_run(mainloop);
+		g_main_loop_run(mainloop);
 	}
 
 	lrmd->lrm_ops->signoff(lrmd);
@@ -620,7 +620,7 @@ lrm_op_timeout(gpointer data)
 	printf("ERROR: This operation has timed out - no result from lrmd.\n");
 
 	*idata = -5;
-	g_main_quit(mainloop);
+	g_main_loop_quit(mainloop);
 	return FALSE;
 }
 
@@ -630,7 +630,7 @@ lrmd_output_dispatch(IPC_Channel* notused, gpointer user_data)
         ll_lrm_t *lrm = (ll_lrm_t*)user_data;
         lrm->lrm_ops->rcvmsg(lrm, FALSE);
 
-	g_main_quit(mainloop);
+	g_main_loop_quit(mainloop);
         return TRUE;
 }
 

--- a/lrm/lrmd/lrmd.c
+++ b/lrm/lrmd/lrmd.c
@@ -972,9 +972,9 @@ static gboolean
 lrm_shutdown(void)
 {
 	lrmd_log(LOG_INFO,"lrmd is shutting down");
-	if (mainloop != NULL && g_main_is_running(mainloop)) {
+	if (mainloop != NULL && g_main_loop_is_running(mainloop)) {
 		g_hash_table_foreach(resources, warning_on_active_rsc, NULL);
-		g_main_quit(mainloop);
+		g_main_loop_quit(mainloop);
 	}else {
 		exit(LSB_EXIT_OK);
 	}
@@ -1279,7 +1279,7 @@ init_start ()
 	}
 
 	/*Create the mainloop and run it*/
-	mainloop = g_main_new(FALSE);
+	mainloop = g_main_loop_new(NULL, FALSE);
 	lrmd_debug(LOG_DEBUG, "main: run the loop...");
 	lrmd_log(LOG_INFO, "Started.");
 
@@ -1287,7 +1287,7 @@ init_start ()
 	init_using_apphb();
 	emit_apphb(NULL); /* Avoid warning */
 
-	g_main_run(mainloop);
+	g_main_loop_run(mainloop);
 
 	emit_apphb(NULL);
         if (reg_to_apphbd == TRUE) {

--- a/lrm/test/callbacktest.c
+++ b/lrm/test/callbacktest.c
@@ -117,8 +117,8 @@ main(int argc, char *argv[])
 		      lrm_dispatch, lrm,
 		      NULL);
 
-	mainloop = g_main_new(FALSE);
-	g_main_run(mainloop);
+	mainloop = g_main_loop_new(NULL, FALSE);
+	g_main_loop_run(mainloop);
 
 	puts("delete_rsc...");
 	lrm->lrm_ops->delete_rsc(lrm, rid);


### PR DESCRIPTION
Fixes build with recent gcc and glib2:
-Werror format-overflow, format-truncation, stringop-truncation (also fixes #23)

glib2 "deprecated symbols" (fixes #24)

@dmuhamedagic :wave: