### PR TITLE
Check instance_id format before sending API

### DIFF
--- a/lib/plugins/stonith/external/ec2
+++ b/lib/plugins/stonith/external/ec2
@@ -351,6 +351,11 @@ fi
 
 is_instance_running || exit 1
 
+if [ ! $instance =~ i-.* ]; then
+	ha_log.sh err "Invalid instance_id"
+	exit 1
+fi
+
 case $action in
 	reboot|reset)
 		status=`instance_status $instance`


### PR DESCRIPTION
When the program fails to get the correct instance_id, $instance will be the hostname for log purpose. Thus the hostname will be send to AWS through API call, which is totally in vain. If the instance_id is not obtained, should fail directly.

Here is an example:

[ An error occurred (InvalidInstanceID.Malformed) when calling the StopInstances operation: Invalid id: "ma1" ]
[ An error occurred (InvalidInstanceID.Malformed) when calling the DescribeInstances operation: Invalid id: "ma1" ]

ma1 is the hostname of the instance and being send through API call.