### PR TITLE
ibmhmc: get the correct hmc version

### DIFF
--- a/lib/plugins/stonith/ibmhmc.c
+++ b/lib/plugins/stonith/ibmhmc.c
@@ -694,7 +694,7 @@ ibmhmc_set_config(StonithPlugin * s, StonithNVpair* list)
 	}		
 
 	/* parse the HMC's version info (i.e. "*RM V4R2.1" or "*RM R3V2.6") */
-	if ((sscanf(output, "*RM %c%1d", &firstchar, &firstnum) == 2)
+	if ((sscanf(output, "*RM %c%d", &firstchar, &firstnum) == 2)
 	&& ((firstchar == 'V') || (firstchar == 'R'))) {
 		dev->hmcver = firstnum;
 		if(Debug){


### PR DESCRIPTION
Currently the logic only get the first digit after 'V'/'R' in the string. So "*RM V10R1.1020.0" will mistakenly recognized as version 1 instead of 10.

ref: bsc#1203635