### PR TITLE
Update ec2 describe-instances filter

### DIFF
--- a/lib/plugins/stonith/external/ec2
+++ b/lib/plugins/stonith/external/ec2
@@ -216,7 +216,7 @@ function instance_for_port()
 	local instance=""
 
 	# Look for port name -n in the INSTANCE data
-	instance=`aws ec2 describe-instances $options --filters "Name=tag-value,Values=${port}" "Name=tag-key,Values=${ec2_tag}" --query 'Reservations[*].Instances[*].InstanceId'  `
+	instance=`aws ec2 describe-instances $options --filters "Name=tag:${ec2_tag},Values=${port}" --query 'Reservations[*].Instances[*].InstanceId'`
 
 	if [ -z $instance ]; then
 		instance_not_found=1


### PR DESCRIPTION
Update ec2 describe-instances filter to return an instance ID that meets the condition `${ec2_tag} = ${port}`
More details on Issue https://github.com/ClusterLabs/cluster-glue/issues/43